### PR TITLE
[README] FTP disabled in favor of HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,74 +17,7 @@ See <http://www.sec.gov/edgar/searchedgar/companysearch.html>
 
 ## Bulk Data
 
-EDGAR provides bulk access via FTP: <ftp://ftp.sec.gov/> - [official
-documentation][ftp-doc]. We summarize here the main points.
-
-Each company in EDGAR gets an identifier known as the CIK which is a 10 digit
-number. You can find the CIK by searching EDGAR using a name of stock market
-ticker.
-
-For example, [searching for IBM by ticker][ibm-search] shows us that
-the the CIK is `0000051143`.
-
-Note that leading zeroes are often omitted (e.g. in the ftp access) so this
-would become `51143`.
-
-[ibm-search]: http://www.sec.gov/cgi-bin/browse-edgar?CIK=ibm&action=getcompany
-
-<img src="http://webshot.okfnlabs.org/api/generate?url=http%3A%2F%2Fwww.sec.gov%2Fcgi-bin%2Fbrowse-edgar%3FCIK%3Dibm%26action%3Dgetcompany&width=1024&height=768" />
-
-Next each submission receives an 'Accession Number' (acc-no). For example,
-IBM's quarterly financial filing (form 10-Q) in October 2013 had accession
-number: `0000051143-13-000007`.
-
-### FTP File Paths
-
-Given a company with CIK (company ID) XXX (omitting leading zeroes) and
-document accession number YYY (acc-no on search results) the path would be:
-
-File paths are of the form:
-
-    /edgar/data/XXX/YYY.txt
-
-For example, for the IBM data above it would be:
-
-<ftp://ftp.sec.gov/edgar/data/51143/0000051143-13-000007.txt>
-
-Note, if you are looking for a nice HTML version you can find it at in the
-Archives section with a similar URL (just add -index.html):
-
-<http://www.sec.gov/Archives/edgar/data/51143/000005114313000007/0000051143-13-000007-index.htm>
-
-### Indices
-
-If you want to get a list of all filings you'll want to grab an Index. As the help page explains:
-
-> The EDGAR indices are a helpful resource for FTP retrieval, listing the
-> following information for each filing: Company Name, Form Type, CIK, Date
-> Filed, and File Name (including folder path).
-> 
-> Four types of indexes are available:
-> 
-> * company — sorted by company name
-> * form — sorted by form type
-> * master — sorted by CIK number
-> * XBRL — list of submissions containing XBRL financial files, sorted by CIK
->   number; these include Voluntary Filer Program submissions
-
-URLs are like:
-
-<ftp://ftp.sec.gov/edgar/full-index/2008/QTR4/master.gz>
-
-That is, they have the following general form:
-
-    ftp://ftp.sec.gov/edgar/full-index/{YYYY}/QTR{1-4}/{index-name}.[gz|zip]
-
-So for XBRL in the 3rd quarter of 2010 we'd do:
-
-<ftp://ftp.sec.gov/edgar/full-index/2010/QTR3/xbrl.gz>
-
-[ftp-doc]: https://www.sec.gov/edgar/searchedgar/ftpusers.htm
+EDGAR provides bulk access via HTTP. See <https://www.sec.gov/edgar/searchedgar/accessing-edgar-data.htm> for details.
 
 ### CIK lists and lookup
 


### PR DESCRIPTION
Per https://www.sec.gov/edgar/searchedgar/accessing-edgar-data.htm

"IMPORTANT NOTE: On Friday, December 30, 2016, at 11:59 pm, Eastern
Time, FTP services for retrieving EDGAR filing documents will be
permanently turned off."